### PR TITLE
Fix ARM instruction `smlabb`

### DIFF
--- a/aarch32/top_arm32.tcc
+++ b/aarch32/top_arm32.tcc
@@ -19276,8 +19276,8 @@ void OpSmlaxy<	ARCH>::execute( ARCH & cpu)
 		op2 = cpu.GetGPR(ra),
 		res = op1 + op2;
 
-		U32 overflow = ((op1 & op2 & (~res)) | ((~op1) & (~op2) & res)) >> 31;
-		cpu.CPSR().Set( Q, BOOL(overflow | cpu.CPSR().Get( Q )) );
+		U32 overflow = ((op1 & op2 & (~res)) | ((~op1) & (~op2) & res)) & U32(0x80000000);
+		cpu.CPSR().Set( Q, BOOL(overflow != U32(0)) | BOOL(cpu.CPSR().Get( Q )) );
 
 		cpu.SetGPR( rd, res );
 }}

--- a/aarch32/top_thumb.tcc
+++ b/aarch32/top_thumb.tcc
@@ -24332,8 +24332,8 @@ void OpSmlaxy<	ARCH>::execute( ARCH & cpu)
 		op2 = cpu.GetGPR(ra),
 		res = op1 + op2;
 
-		U32 overflow = ((op1 & op2 & (~res)) | ((~op1) & (~op2) & res)) >> 31;
-		cpu.CPSR().Set( Q, BOOL(overflow | cpu.CPSR().Get( Q )) );
+		U32 overflow = ((op1 & op2 & (~res)) | ((~op1) & (~op2) & res)) & U32(0x80000000);
+		cpu.CPSR().Set( Q, BOOL(overflow != U32(0)) | BOOL(cpu.CPSR().Get( Q )) );
 
 		cpu.SetGPR( rd, res );
 }}


### PR DESCRIPTION
ARM instruction `smlabb` (Signed Multiply Accumulate Long) was not supported by BINSEC:

    $ binsec -isa arm32 -arm-supported-modes arm -disasm-decode 812401e1
    [disasm:result] e1 01 24 81 / smlabb        r1, r1, r4, r2
                     0: #unsupported smlabb     r1, r1, r4, r2

    $ binsec -isa arm32 -arm-supported-modes thumb -disasm-decode 11fb0421
    [disasm:result] 21 04 fb 11 / smlabb        r1, r1, r4, r2
                     0: #unsupported smlabb     r1, r1, r4, r2

The expression needed a fix. With it, the instructions are correctly decoded, both in ARM and Thumb modes:

    $ binsec -isa arm32 -arm-supported-modes arm -disasm-decode 812401e1
    [disasm:result] e1 01 24 81 / smlabb        r1, r1, r4, r2
                     0: %%0<32> :=
                         ((exts r1<32>{0,15} 32) * (exts r4<32>{0,15} 32));
                     1: %%1<32> := (%%0<32> + r2<32>);
                     2: %%2<1> :=
                         ((0<32> <>
                           (0x80000000 &
                            (((%%0<32> & r2<32>) & ! (%%1<32>)) |
                             ((! (%%0<32>) & ! (r2<32>)) & %%1<32>)))) | q<1>);
                     3: q<1> := %%2<1>;
                     4: r1<32> := %%1<32>;
                     5: goto (0x00000004, 0)

    $ binsec -isa arm32 -arm-supported-modes thumb -disasm-decode 11fb0421
    [disasm:result] 21 04 fb 11 / smlabb        r1, r1, r4, r2
                     0: %%0<32> :=
                         ((exts r1<32>{0,15} 32) * (exts r4<32>{0,15} 32));
                     1: %%1<32> := (%%0<32> + r2<32>);
                     2: %%2<1> :=
                         ((0<32> <>
                           (0x80000000 &
                            (((%%0<32> & r2<32>) & ! (%%1<32>)) |
                             ((! (%%0<32>) & ! (r2<32>)) & %%1<32>)))) | q<1>);
                     3: q<1> := %%2<1>;
                     4: r1<32> := %%1<32>;
                     5: goto (0x00000004, 0)

Fixes: https://github.com/binsec/binsec/issues/32